### PR TITLE
- Fix maven surefire plugin such that running `mvn test` or a higher lifecycle method, will indeed run our tests.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M4</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -128,15 +134,10 @@
                 <version>9.4.12.v20180830</version>
             </plugin>
 
-            <!-- Default is too old, update to latest to run the latest Spring 5 + jUnit 5 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
-                <configuration>
-                    <useSystemClassLoader>false</useSystemClassLoader>
-                    <encoding>UTF-8</encoding>
-                </configuration>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.0</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
- Fix maven surefire plugin such that running `mvn test` or a higher lifecycle method, will indeed run our tests.

Signed-off-by: ShaneCreedon <shane.creedon@brightflag.com>